### PR TITLE
ASM-2835: Fix perms of graphite DB

### DIFF
--- a/scripts/rpm/postInstall.sh
+++ b/scripts/rpm/postInstall.sh
@@ -16,6 +16,7 @@ then
   echo "TIME_ZONE = 'UTC'" >> /etc/graphite-web/local_settings.py
 
   python /usr/lib/python2.6/site-packages/graphite/manage.py syncdb --noinput
+  chown apache:apache /var/lib/graphite-web/graphite.db
 
   cat << EOF > /etc/carbon/storage-schemas.conf
 [carbon]


### PR DESCRIPTION
We initialize the db in the rpm post install which runs as root however
the db should be owned by the werbserver

Ideally I'd su apache -c ... this but apache user is locked so this is
2nd best option