### PR TITLE
ASM-4063 add cache directory to deployer rpm

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,7 +84,8 @@ task rpm() << {
     // as root user. For now making this directory as world-writeable with sticky bit (like /tmp)
     // so that different users can't clobber each other's files. Longer-term the scvmm script
     // should also be run by puppet-script-device and then this could be owned by razor:razor 0755
-    rpmBuilder.addDirectory("/opt/Dell/ASM/cache", 1777, Directive.NONE, 'root', 'root', false)
+    // Directory ownership is changed to tomcat:tomcat. Root user can read and write with any permission
+    rpmBuilder.addDirectory("/opt/Dell/ASM/cache", 1777, Directive.NONE, 'tomcat', 'tomcat', false)
 
     // Install directory.
     // Installed as root:razor with 0775 so that torquebox can write the Gemfile.lock file.

--- a/build.gradle
+++ b/build.gradle
@@ -84,8 +84,8 @@ task rpm() << {
     // as root user. For now making this directory as world-writeable with sticky bit (like /tmp)
     // so that different users can't clobber each other's files. Longer-term the scvmm script
     // should also be run by puppet-script-device and then this could be owned by razor:razor 0755
-    // Directory ownership is changed to tomcat:tomcat. Root user can read and write with any permission
-    rpmBuilder.addDirectory("/opt/Dell/ASM/cache", 1777, Directive.NONE, 'tomcat', 'tomcat', false)
+    // Directory ownership is changed to tomcat:tomcat and permission to 0755
+    rpmBuilder.addDirectory("/opt/Dell/ASM/cache", 0755, Directive.NONE, 'tomcat', 'tomcat', false)
 
     // Install directory.
     // Installed as root:razor with 0775 so that torquebox can write the Gemfile.lock file.


### PR DESCRIPTION
Updated the directory ownership to tomcat:tomcat to ensure scvmm discovery which runs as a tomcat user and equallogic discovery running as "root" user can read and write in this directory.