### PR TITLE
ASM-4070 add asm-deployer jobs output directory

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -76,6 +76,9 @@ task rpm() << {
     // Directory where REST service will write deployment information
     rpmBuilder.addDirectory("/opt/Dell/ASM/deployments", 0775, Directive.NONE, 'razor', 'razor', false)
 
+    // Directory where REST service will write deployment information
+    rpmBuilder.addDirectory("/opt/Dell/ASM/jobs", 0775, Directive.NONE, 'razor', 'razor', false)
+
     // Directory for writing puppet device call log files
     rpmBuilder.addDirectory("/opt/Dell/ASM/device", 0775, Directive.NONE, 'razor', 'razor', false)
 


### PR DESCRIPTION
Queued inventory and puppet_apply jobs will have output files stored
under /opt/Dell/ASM/jobs/[CERTNAME]