### PR TITLE
ASM-4473: Add logrotation and disable more logging

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -124,6 +124,8 @@ task rpm() << {
                 rpmBuilder.addFile("/etc/cron.d/asm_nagios", it.file, 0644, Directive.NONE, 'root', 'root')
             } else if (it.path == "nagios/graphite-web.conf") {
                 rpmBuilder.addFile("/etc/httpd/conf.d/asm-graphite-web.conf", it.file, 0644, Directive.NONE, 'root', 'root')
+            } else if (it.path == "nagios/logrotate.graphite") {
+                rpmBuilder.addFile("/etc/logrotate.d/graphite", it.file, 0644, Directive.NONE, 'root', 'root')
             } else {
                 rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0644, Directive.NONE, 'root', 'razor')
             }

--- a/scripts/rpm/postInstall.sh
+++ b/scripts/rpm/postInstall.sh
@@ -8,6 +8,12 @@
 /sbin/restorecon -v /usr/lib64/nagios/plugins/*
 
 # configure graphite
+touch /etc/carbon/storage-aggregation.conf
+
+/bin/sed -i 's:LOG_LISTENER_CONNECTIONS = True:LOG_LISTENER_CONNECTIONS = False:' /etc/carbon/carbon.conf
+/bin/sed -i 's:LOG_CACHE_QUEUE_SORTS = True:LOG_CACHE_QUEUE_SORTS = False:' /etc/carbon/carbon.conf
+/bin/sed -i 's:ENABLE_LOGROTATION = True:ENABLE_LOGROTATION = False:' /etc/carbon/carbon.conf
+
 grep -q ^SECRET_KEY /etc/graphite-web/local_settings.py
 
 if [ $? -eq 1 ]
@@ -31,9 +37,9 @@ retentions = 1h:30d, 1d:5y
 pattern = .*
 retentions = 5m:30d, 1h:1y, 1d:5y
 EOF
-  
+
   /bin/sed -i 's:^:#:' /etc/httpd/conf.d/graphite-web.conf
-  
+
   chkconfig carbon-cache on
 fi
 


### PR DESCRIPTION
This adds a logrotate config file for the graphite logs as well as
disable some logging settings in the config

carbon-cache was logging a lot about missing storage-aggregation.conf
which we don't use so this also just touches the file