### PR TITLE
Change Gemfile.lock permissions

### DIFF
--- a/scripts/rpm/postInstall.sh
+++ b/scripts/rpm/postInstall.sh
@@ -16,6 +16,11 @@ touch /etc/carbon/storage-aggregation.conf
 
 grep -q ^SECRET_KEY /etc/graphite-web/local_settings.py
 
+if [ -e "/opt/asm-deployer/Gemfile.lock" ]
+  then
+  chown root:razor "/opt/asm-deployer/Gemfile.lock" && chmod 0664 "/opt/asm-deployer/Gemfile.lock"
+fi
+
 if [ $? -eq 1 ]
 then
   echo "SECRET_KEY = '$(openssl rand 32 -hex)'" >> /etc/graphite-web/local_settings.py
@@ -42,4 +47,3 @@ EOF
 
   chkconfig carbon-cache on
 fi
-


### PR DESCRIPTION
This is for backwards compatability if the appliance was created with
the wrong permissions on the Gemfile.lock, we will be unable to install
any added Gem dependencies added to the Gemfile.