### PR TITLE
ASM-4913 ensure rpm gem updates used by asm-deployer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,8 +34,19 @@ buildscript {
     }
 }
 
+// asm-deployer is expected to be checked out in a directory at the same level
+// as this directory. Copy it into the build directory, modifying the Gemfile
+// along the way to remove direct git dependencies since asm-deployer needs to
+// use the gems that are installed by the Dell-ASM-Gems rpm.
+task copyAsmDeployer(type: Copy) {
+    from "${projectDir}/../asm-deployer"
+    into "${buildDir}/files"
+    filesMatching("Gemfile", {
+        filter({ ln -> ln.replaceAll(/, :git => ['"].*['"]/, "") })
+    })
+}
 
-task rpm() << {
+task rpm(dependsOn: copyAsmDeployer) << {
     File rpmDestinationDirectory = new File("${buildDir}/distributions")
     if (!rpmDestinationDirectory.isDirectory()) {
         rpmDestinationDirectory.mkdirs()
@@ -98,7 +109,7 @@ task rpm() << {
     rpmBuilder.addDirectory("/opt/asm-deployer", 0775, Directive.NONE, 'root', 'razor', false)
 
     // Add files copied from https://github.com/dell-asm/asm-deployer
-    fileTree(dir: '../asm-deployer', include: '**').visit {
+    fileTree(dir: "${buildDir}/files", include: '**').visit {
         if (it.file.isDirectory() && !it.file.name.equals(".svn")) {
             rpmBuilder.addDirectory("/opt/asm-deployer/${it.path}", 0755, Directive.NONE, 'root', 'razor', false)
         } else if (it.file.isFile()) {


### PR DESCRIPTION
The asm-deployer Gemfile has to depend on the git version of the
dell-asm-util gem so that Travis CI tests can run with the latest
version of that code. However, the appliance needs to use the version
of dell-asm-util that is included in the appliance Dell-ASM-Gems
rpm. Modify the asm-deployer rpm gradle build to simply remove the
:git tag from the dell-asm-util dependency so that the installed
dell-asm-util gem will be used.