### PR TITLE
ASM-6162 Hyperv VM post-installation failing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -121,6 +121,9 @@ task rpm(dependsOn: copyAsmDeployer) << {
         } else if (it.file.isFile()) {
             if ('lib/asm/scvmm_cluster_ip.rb' == it.path ||
                 'lib/asm/scvmm_macaddress.rb' == it.path ||
+                'lib/asm/scvmm_vm_nic_info.rb' == it.path ||
+                'lib/asm/scvmm_vminfo.rb' == it.path ||
+                'lib/asm/scvmm_cluster_information.rb' == it.path ||
                 it.path.startsWith('scripts/')) {
                 rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0755, Directive.NONE, 'root', 'razor')
             } else if (it.path == "nagios/nagios-export.rb") {


### PR DESCRIPTION
Execute permission was missing from the ruby script used for identifying the OS version of the VM. As a result VM post-installation of clone VM was getting skipped.