### PR TITLE
ASM-8346 limit maximum nagios checks to 4

### DIFF
--- a/scripts/rpm/postInstall.sh
+++ b/scripts/rpm/postInstall.sh
@@ -3,6 +3,7 @@
 
 /bin/sed -i 's:enable_notifications=1:enable_notifications=0:' /etc/nagios/nagios.cfg
 /bin/sed -i 's:enable_flap_detection=1:enable_flap_detection=0:' /etc/nagios/nagios.cfg
+/bin/sed -i 's:max_concurrent_checks=0:max_concurrent_checks=4:' /etc/nagios/nagios.cfg
 /bin/sed -i 's:cfg_file=/etc/nagios/objects/localhost.cfg:#cfg_file=/etc/nagios/objects/localhost.cfg:' /etc/nagios/nagios.cfg
 
 /sbin/restorecon -v /usr/lib64/nagios/plugins/*


### PR DESCRIPTION
This changes the max nagios concurrent nagios checks from unlimited to
4, this will have an impact on how quickly issues are detected on
hardware especially on setups with many resources but it wont consume
all the resources anymore

If there is docs about setting up a split nagios / deployer scenario we
should mention that the max_concurrent_checks should be set back to 0 if
there is a dedicated nagios worker node