### PR TITLE
Revert "ASM-8346 limit maximum nagios checks to 4"

### DIFF
--- a/scripts/rpm/postInstall.sh
+++ b/scripts/rpm/postInstall.sh
@@ -4,6 +4,7 @@
 /bin/sed -i 's:enable_notifications=1:enable_notifications=0:' /etc/nagios/nagios.cfg
 /bin/sed -i 's:enable_flap_detection=1:enable_flap_detection=0:' /etc/nagios/nagios.cfg
 /bin/sed -i 's:cfg_file=/etc/nagios/objects/localhost.cfg:#cfg_file=/etc/nagios/objects/localhost.cfg:' /etc/nagios/nagios.cfg
+/bin/sed -i 's:max_concurrent_checks=4:max_concurrent_checks=0:' /etc/nagios/nagios.cfg
 
 /sbin/restorecon -v /usr/lib64/nagios/plugins/*
 

--- a/scripts/rpm/postInstall.sh
+++ b/scripts/rpm/postInstall.sh
@@ -3,7 +3,6 @@
 
 /bin/sed -i 's:enable_notifications=1:enable_notifications=0:' /etc/nagios/nagios.cfg
 /bin/sed -i 's:enable_flap_detection=1:enable_flap_detection=0:' /etc/nagios/nagios.cfg
-/bin/sed -i 's:max_concurrent_checks=0:max_concurrent_checks=4:' /etc/nagios/nagios.cfg
 /bin/sed -i 's:cfg_file=/etc/nagios/objects/localhost.cfg:#cfg_file=/etc/nagios/objects/localhost.cfg:' /etc/nagios/nagios.cfg
 
 /sbin/restorecon -v /usr/lib64/nagios/plugins/*


### PR DESCRIPTION
This reverts commit 438bad0689868955f4fcb364e3ee3e5d40c7f7e2.

The effect of this combined with the pattern in use by the load short
circuit service has the effect that the load short circuit checks are
skipped under load - and so the short circuit pattern is often not
effective

After discussion we felt the short circuit is going to be a better long
term way to combat the load problems - at the cost of short spikes where
many checks will be called when the node crosses the threshold of low
load to high load