### PR TITLE
ASM-8606 Run "bundle update --local" from post-install script

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
     ext {
         env = System.getenv()
         buildNumber = env.BUILD_NUMBER ? env.BUILD_NUMBER.toString() : ((int) (System.currentTimeMillis() / 1000)).toString()
-        BASE_REPO_URL = hasProperty('BASE_REPO_URL') ? BASE_REPO_URL : 'http://10.35.178.198:8081/artifactory'
+        BASE_REPO_URL = hasProperty('BASE_REPO_URL') ? BASE_REPO_URL : 'http://172.20.201.85:8081/artifactory'
         PLUGINS_REPO = hasProperty('PLUGINS_REPO') ? asmnext - trunk - external : 'plugins-release'
         PLUGINS_REPO_URL = hasProperty('PLUGINS_REPO_URL') ? PLUGINS_REPO_URL : "${BASE_REPO_URL}/${PLUGINS_REPO}"
         rpm_packageName = env.RPM_PACKAGENAME ? env.RPM_PACKAGENAME : 'Dell-ASM-asm-deployer'

--- a/scripts/rpm/postInstall.sh
+++ b/scripts/rpm/postInstall.sh
@@ -15,13 +15,6 @@ touch /etc/carbon/storage-aggregation.conf
 /bin/sed -i 's:LOG_CACHE_QUEUE_SORTS = True:LOG_CACHE_QUEUE_SORTS = False:' /etc/carbon/carbon.conf
 /bin/sed -i 's:ENABLE_LOGROTATION = True:ENABLE_LOGROTATION = False:' /etc/carbon/carbon.conf
 
-# Update Gemfile.lock for Torquebox 3.0.2
-GEMFILE_LOCK=/opt/asm-deployer/Gemfile.lock
-if [ -e $GEMFILE_LOCK ]
-then
-  sed -i -e 's/\(torque.*\)\((= 3.0.[0-9])\)/\1(= 3.0.2)/' $GEMFILE_LOCK
-fi
-
 grep -q ^SECRET_KEY /etc/graphite-web/local_settings.py
 
 if [ $? -eq 1 ]
@@ -50,3 +43,7 @@ EOF
 
   chkconfig carbon-cache on
 fi
+
+# Pick up local gem changes from Dell-ASM-Gems
+cd /opt/asm-deployer
+/opt/jruby-1.7.8/bin/bundle update --local


### PR DESCRIPTION
This used to be done in Dell-ASM-Gems, but it is more approriate
here. This rpm already has a dependency on Dell-ASM-Gems so that it
gets upgraded first. This way "bundle update --local" will be run
after the new gems are installed and after the asm-deployer Gemfile
has been updated to match.

Also removed the sed of Gemfile.lock since "bundle update --local"
will do it.