### PR TITLE
[misc] Add Gemfile.lock for asm-deployer

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -111,9 +111,9 @@ task rpm(dependsOn: copyAsmDeployer) << {
     rpmBuilder.addDirectory("/opt/Dell/ASM/modules", 0755, Directive.NONE, 'nobody', 'nobody', false)
 
     // Install directory.
-    // Installed as root:razor with 0775 so that torquebox can write the Gemfile.lock file.
-    // Torquebox should not need to write any other files into /opt/asm-deployer
-    rpmBuilder.addDirectory("/opt/asm-deployer", 0775, Directive.NONE, 'root', 'razor', false)
+    rpmBuilder.addDirectory("/opt/asm-deployer", 0755, Directive.NONE, 'root', 'razor', false)
+
+    rpmBuilder.addFile("/opt/asm-deployer/Gemfile.lock", file("files/Gemfile.lock"), 0644, Directive.NONE, 'root', 'razor')
 
     // Add files copied from https://github.com/dell-asm/asm-deployer
     fileTree(dir: "${buildDir}/files", include: '**').visit {

--- a/files/Gemfile.lock
+++ b/files/Gemfile.lock
@@ -1,0 +1,188 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aescrypt (1.0.0)
+    ast (2.2.0)
+    builder (3.2.2)
+    coderay (1.1.0)
+    concurrent-ruby (1.0.0-java)
+    dell-asm-util (0.1.0)
+      aescrypt (~> 1.0.0)
+      hashie (>= 2.0.5)
+      i18n (~> 0.6.5)
+      net-ssh (~> 2.7)
+      nokogiri (~> 1.6.8)
+      pry (~> 0.10)
+      rest-client (= 1.8.0)
+      trollop (~> 2.0)
+    diff-lcs (1.2.5)
+    domain_name (0.5.20160128)
+      unf (>= 0.0.5, < 1.0.0)
+    facter (2.4.6)
+    ffi (1.9.17-java)
+    fishwife (1.8.1-java)
+      rack (>= 1.5.2, < 1.7)
+      rjack-jetty (>= 9.2.11, < 9.4)
+      rjack-slf4j (~> 1.7.2)
+    formatador (0.2.5)
+    guard (2.13.0)
+      formatador (>= 0.2.4)
+      listen (>= 2.7, <= 4.0)
+      lumberjack (~> 1.0)
+      nenv (~> 0.1)
+      notiffany (~> 0.0)
+      pry (>= 0.9.12)
+      shellany (~> 0.0)
+      thor (>= 0.18.1)
+    guard-compat (1.2.1)
+    guard-shell (0.7.1)
+      guard (>= 2.0.0)
+      guard-compat (~> 1.0)
+    hashie (3.3.1)
+    hiera (3.0.6)
+      json_pure
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    i18n (0.6.9)
+    jdbc-postgres (9.2.1002.1)
+    jruby-openssl (0.9.18-java)
+    json_pure (2.0.1)
+    kramdown (1.9.0)
+    listen (3.0.5)
+      rb-fsevent (>= 0.9.3)
+      rb-inotify (>= 0.9)
+    logger-colors (1.0.0)
+    lumberjack (1.0.10)
+    metaclass (0.0.4)
+    method_source (0.8.2)
+    mime-types (2.99)
+    mocha (1.1.0)
+      metaclass (~> 0.0.1)
+    nenv (0.2.0)
+    net-ssh (2.9.4)
+    netrc (0.11.0)
+    nokogiri (1.6.8-java)
+    notiffany (0.0.8)
+      nenv (~> 0.1)
+      shellany (~> 0.0)
+    parser (2.3.3.1)
+      ast (~> 2.2)
+    powerpack (0.1.1)
+    pry (0.10.3-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    puppet (4.3.2)
+      facter (> 2.0, < 4)
+      hiera (>= 2.0, < 4)
+      json_pure
+    puppetlabs_spec_helper (0.4.1)
+      mocha (>= 0.10.5)
+      rake
+      rspec (>= 2.9.0)
+      rspec-puppet (>= 0.1.1)
+    rack (1.6.4)
+    rack-protection (1.5.3)
+      rack
+    rainbow (2.1.0)
+    rake (11.1.2)
+    rb-fsevent (0.9.7)
+    rb-inotify (0.9.5)
+      ffi (>= 0.5.0)
+    rbvmomi (1.6.0)
+      builder
+      nokogiri (>= 1.4.1)
+      trollop
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 3.0)
+      netrc (~> 0.7)
+    rjack-jetty (9.3.11.0-java)
+    rjack-logback (1.8.1-java)
+      rjack-slf4j (~> 1.7.16)
+    rjack-slf4j (1.7.19.0-java)
+    rspec (3.4.0)
+      rspec-core (~> 3.4.0)
+      rspec-expectations (~> 3.4.0)
+      rspec-mocks (~> 3.4.0)
+    rspec-core (3.4.4)
+      rspec-support (~> 3.4.0)
+    rspec-expectations (3.4.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-mocks (3.4.1)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.4.0)
+    rspec-puppet (2.3.2)
+      rspec
+    rspec-support (3.4.1)
+    rubocop (0.41.2)
+      parser (>= 2.3.1.1, < 3.0)
+      powerpack (~> 0.1)
+      rainbow (>= 1.99.1, < 3.0)
+      ruby-progressbar (~> 1.7)
+      unicode-display_width (~> 1.0, >= 1.0.1)
+    ruby-progressbar (1.7.5)
+    sequel (4.43.0)
+    shellany (0.0.1)
+    sinatra (1.4.5)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    slop (3.6.0)
+    spoon (0.0.4)
+      ffi
+    thor (0.19.1)
+    tilt (1.4.1)
+    trollop (2.0)
+    unf (0.1.4-java)
+    unicode-display_width (1.0.2)
+    yard (0.8.7.6)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  aescrypt (= 1.0.0)
+  concurrent-ruby (~> 1.0.0)
+  coveralls
+  dell-asm-util
+  fishwife
+  guard-shell
+  hashie (= 3.3.1)
+  i18n (= 0.6.9)
+  jdbc-postgres (~> 9.2.1002.1)
+  jruby-openssl (~> 0.9.17)
+  json_pure (= 2.0.1)
+  kramdown
+  listen (~> 3.0.0)
+  logger-colors (~> 1.0.0)
+  mocha
+  nokogiri (= 1.6.8)
+  pg (= 0.17.1)
+  puppet
+  puppetlabs_spec_helper (= 0.4.1)
+  rainbow (~> 2.1.0)
+  rake
+  rbvmomi (= 1.6.0)
+  rest-client (= 1.8.0)
+  rjack-logback
+  rspec (~> 3.4.0)
+  rubocop (= 0.41.2)
+  ruby-prof (~> 0.15.8)
+  sequel (= 4.43.0)
+  sinatra (= 1.4.5)
+  sys-admin
+  trollop (= 2.0)
+  unicode-display_width
+  win32-dir
+  win32-process
+  win32-security
+  win32-service
+  win32-taskscheduler
+  windows-pr
+  yard
+
+BUNDLED WITH
+   1.14.3

--- a/scripts/rpm/postInstall.sh
+++ b/scripts/rpm/postInstall.sh
@@ -46,7 +46,3 @@ EOF
 
   chkconfig carbon-cache on
 fi
-
-# Pick up local gem changes from Dell-ASM-Gems
-cd /opt/asm-deployer
-env PATH=/opt/jruby/9k/bin:$PATH bundle update --local


### PR DESCRIPTION
Previously the Gemfile.lock was not included in the asm-deployer
rpm. "bundle update --local" was run as a postinstall script in order
to generate it based on what gems were installed on the
appliance. That makes it very difficult to determine what gems are
_supposed_ to be included on the appliance.

This commit adds the Gemfile.lock to the rpm and removes the "bundle
update --local" post-install. Also tightens up permissions on
/opt/asm-deployer since we no longer expect torquebox to write into
that directory.