### PR TITLE
ASM-6900 Create files for easy VM Cloning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -115,6 +115,11 @@ task rpm(dependsOn: copyAsmDeployer) << {
 
     rpmBuilder.addFile("/opt/asm-deployer/Gemfile.lock", file("files/Gemfile.lock"), 0644, Directive.NONE, 'root', 'razor')
 
+    //Add cloneVM files
+    rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.sh", file("${buildDir}/files/scripts/puppet_certname.sh"), 0755, Directive.NONE, 'razor', 'razor')
+    rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.rb", file("${buildDir}/files/scripts/puppet_certname.rb"), 0755, Directive.NONE, 'razor', 'razor')
+
+
     // Add files copied from https://github.com/dell-asm/asm-deployer
     fileTree(dir: "${buildDir}/files", include: '**').visit {
         if (it.file.isDirectory() && !it.file.name.equals(".svn")) {
@@ -166,6 +171,7 @@ task rpm(dependsOn: copyAsmDeployer) << {
         }
     }
 
+    rpmBuilder.addDependencyMore('Dell-ASM-razor-server-repo-store', project.rpm_version)
     rpmBuilder.setPackage(project.rpm_packageName, project.rpm_version, project.buildNumber.toString())
     rpmBuilder.setType(RpmType.BINARY)
     rpmBuilder.setPlatform(Architecture.NOARCH, 'LINUX')


### PR DESCRIPTION
The ASM Installation Guide documents the process for preparing VM
clone images for use in ASM deployments. Part of that process
involves copying script files from the ASM appliance and
downloading ruby gems from the internet. This change consolidates
all the needed files into a single location on the appliance
accessible via its CIFS share.