### PR TITLE
ASM-6900 Create files for easy VM Cloning

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,6 +118,7 @@ task rpm(dependsOn: copyAsmDeployer) << {
     //Add cloneVM files
     rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.sh", file("${buildDir}/files/scripts/puppet_certname.sh"), 0755, Directive.NONE, 'razor', 'razor')
     rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.rb", file("${buildDir}/files/scripts/puppet_certname.rb"), 0755, Directive.NONE, 'razor', 'razor')
+    rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.bat", file("${buildDir}/files/scripts/puppet_certname.bat"), 0644, Directive.NONE, 'razor', 'razor')
 
 
     // Add files copied from https://github.com/dell-asm/asm-deployer


### PR DESCRIPTION
The ASM Installation Guide documents the process for preparing VM
clone images for use in ASM deployments. Part of that process
involves copying script files from the ASM appliance and
downloading ruby gems from the internet. This change consolidates
all the needed files into a single location on the appliance
accessible via its CIFS share.