### PR TITLE
[misc] Update rubocop gem

### DIFF
--- a/files/Gemfile.lock
+++ b/files/Gemfile.lock
@@ -117,8 +117,8 @@ GEM
     rspec-puppet (2.3.2)
       rspec
     rspec-support (3.4.1)
-    rubocop (0.41.2)
-      parser (>= 2.3.1.1, < 3.0)
+    rubocop (0.47.1)
+      parser (>= 2.3.3.1, < 3.0)
       powerpack (~> 0.1)
       rainbow (>= 1.99.1, < 3.0)
       ruby-progressbar (~> 1.7)
@@ -169,7 +169,7 @@ DEPENDENCIES
   rest-client (= 1.8.0)
   rjack-logback
   rspec (~> 3.4.0)
-  rubocop (= 0.41.2)
+  rubocop (= 0.47.1)
   ruby-prof (~> 0.15.8)
   sequel (= 4.43.0)
   sinatra (= 1.4.5)


### PR DESCRIPTION
I revved the rubocop version recently in asm-deployer. That was
intended to be a dev-only change but since all gems are included on
the appliance gem updates will fail if the same change isn't included
in the gems rpm and the asm-deployer Gemfile.lock.