### PR TITLE
[maint] RPM fixes in preparation for CentOS 7

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,13 +11,13 @@ buildscript {
     ext {
         env = System.getenv()
         buildNumber = env.BUILD_NUMBER ? env.BUILD_NUMBER.toString() : ((int) (System.currentTimeMillis() / 1000)).toString()
-        BASE_REPO_URL = hasProperty('BASE_REPO_URL') ? BASE_REPO_URL : 'http://172.20.201.85:8081/artifactory'
+        BASE_REPO_URL = hasProperty('BASE_REPO_URL') ? BASE_REPO_URL : 'http://artifactory.asm.delllabs.net:8080/artifactory'
         PLUGINS_REPO = hasProperty('PLUGINS_REPO') ? asmnext - trunk - external : 'plugins-release'
         PLUGINS_REPO_URL = hasProperty('PLUGINS_REPO_URL') ? PLUGINS_REPO_URL : "${BASE_REPO_URL}/${PLUGINS_REPO}"
         rpm_packageName = env.RPM_PACKAGENAME ? env.RPM_PACKAGENAME : 'Dell-ASM-asm-deployer'
         rpm_description = env.RPM_DESCRIPTION ? env.RPM_DESCRIPTION : 'asm-deployer for Dell ASM'
         rpm_summary = env.RPM_SUMMARY ? env.RPM_SUMMARY : 'asm-deployer for Dell ASM'
-        rpm_version = env.RPM_VERSION ? env.RPM_VERSION : '8.2.0'
+        rpm_version = env.RPM_VERSION ? env.RPM_VERSION : '8.4.0'
         rpm_vendor = env.RPM_VENDOR ? env.RPM_VENDOR : 'Dell, Inc.'
         rpm_url = env.RPM_URL ? env.RPM_URL : 'http://www.dell.com/'
         rpm_license = env.RPM_LICENSE ? env.RPM_LICENSE : 'DELL END USER LICENSE AGREEMENT - TYPE A'
@@ -30,7 +30,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'org.redline-rpm:redline:1.2.4'
+        classpath 'org.redline-rpm:redline:1.2.6'
     }
 }
 
@@ -116,12 +116,12 @@ task rpm(dependsOn: copyAsmDeployer) << {
     // Install directory.
     rpmBuilder.addDirectory("/opt/asm-deployer", 0755, Directive.NONE, 'root', 'razor', false)
 
-    rpmBuilder.addFile("/opt/asm-deployer/Gemfile.lock", file("files/Gemfile.lock"), 0644, Directive.NONE, 'root', 'razor')
+    rpmBuilder.addFile("/opt/asm-deployer/Gemfile.lock", file("files/Gemfile.lock"), 0644, -1, Directive.NONE, 'root', 'razor', false)
 
     //Add cloneVM files
-    rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.sh", file("${buildDir}/files/scripts/puppet_certname.sh"), 0755, Directive.NONE, 'razor', 'razor')
-    rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.rb", file("${buildDir}/files/scripts/puppet_certname.rb"), 0755, Directive.NONE, 'razor', 'razor')
-    rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.bat", file("${buildDir}/files/scripts/puppet_certname.bat"), 0644, Directive.NONE, 'razor', 'razor')
+    rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.sh", file("${buildDir}/files/scripts/puppet_certname.sh"), 0755, -1, Directive.NONE, 'razor', 'razor', false)
+    rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.rb", file("${buildDir}/files/scripts/puppet_certname.rb"), 0755, -1, Directive.NONE, 'razor', 'razor', false)
+    rpmBuilder.addFile("/var/lib/razor/repo-store/puppet-agent/cloneVM/puppet_certname.bat", file("${buildDir}/files/scripts/puppet_certname.bat"), 0644, -1, Directive.NONE, 'razor', 'razor', false)
 
 
     // Add files copied from https://github.com/dell-asm/asm-deployer
@@ -136,43 +136,43 @@ task rpm(dependsOn: copyAsmDeployer) << {
                 'lib/asm/scvmm_cluster_information.rb' == it.path ||
                 'lib/asm/winrm_reconfigure.rb' == it.path ||
                 it.path.startsWith('scripts/')) {
-                rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0755, Directive.NONE, 'root', 'razor')
+                rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0755, -1, Directive.NONE, 'root', 'razor', false)
             } else if (it.path == "asm-deployer.init") {
-                rpmBuilder.addFile("/etc/init.d/asm-deployer", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/etc/init.d/asm-deployer", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/nagios-export.rb") {
-                rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/poll_idrac8_sensors.rb") {
-                rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check-ipmi.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check-ipmi.rb", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check-ipmi.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check-racadm.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check-racadm.rb", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check-racadm.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check_snmp.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_snmp.rb", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_snmp.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check_navisec.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_navisec.rb", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_navisec.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check_unisphere.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_unisphere.rb", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_unisphere.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check_wsman_power.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_wsman_power.rb", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_wsman_power.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check-wsman.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check-wsman.rb", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check-wsman.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check_esxi_maintmode.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_esxi_maintmode.rb", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_esxi_maintmode.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check_esxi_hardware.py") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_esxi_hardware.py", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_esxi_hardware.py", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/load_short_circuit.sh") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/load_short_circuit.sh", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/load_short_circuit.sh", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/process_nagios_status.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/process_nagios_status.rb", it.file, 0755, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/process_nagios_status.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/asm_nagios.cron") {
-                rpmBuilder.addFile("/etc/cron.d/asm_nagios", it.file, 0644, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/etc/cron.d/asm_nagios", it.file, 0644, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/graphite-web.conf") {
-                rpmBuilder.addFile("/etc/httpd/conf.d/asm-graphite-web.conf", it.file, 0644, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/etc/httpd/conf.d/asm-graphite-web.conf", it.file, 0644, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/logrotate.graphite") {
-                rpmBuilder.addFile("/etc/logrotate.d/graphite", it.file, 0644, Directive.NONE, 'root', 'root')
+                rpmBuilder.addFile("/etc/logrotate.d/graphite", it.file, 0644, -1, Directive.NONE, 'root', 'root', false)
             } else {
-                rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0644, Directive.NONE, 'root', 'razor')
+                rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0644, -1, Directive.NONE, 'root', 'razor', false)
             }
         }
     }


### PR DESCRIPTION
In general all Redline `Builder.addFile(...)` or
`Builder.addDirectory(...)` calls need to set the `addParents` boolean
to false. It unhelpfully defaults to true. When set to false it claims
ownership of all parent directories in addition to the actual path
specified. Yum in CentOS 7 will refuse to install RPMs that claim to
own the same directory as another RPM.