### PR TITLE
LUD-221 Add net-scp to asm-deployer Gemfile.lock

### DIFF
--- a/files/Gemfile.lock
+++ b/files/Gemfile.lock
@@ -65,6 +65,8 @@ GEM
     mocha (1.3.0)
       metaclass (~> 0.0.1)
     nenv (0.3.0)
+    net-scp (1.2.1)
+      net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
     netrc (0.11.0)
     nokogiri (1.8.2-java)
@@ -166,6 +168,8 @@ DEPENDENCIES
   listen (~> 3.1.5)
   logger-colors (~> 1.0.0)
   mocha
+  net-scp
+  net-ssh
   nokogiri (~> 1.8.2)
   pg (~> 1.0.0)
   puppet


### PR DESCRIPTION
net-scp is required in order to copy files to the ScaleIO Gateway VM
via SCP.