### PR TITLE
LUD-513 Downgrade to nokogiri 1.7.2-java due to memory issues

### DIFF
--- a/files/Gemfile.lock
+++ b/files/Gemfile.lock
@@ -69,7 +69,7 @@ GEM
       net-ssh (>= 2.6.5)
     net-ssh (4.2.0)
     netrc (0.11.0)
-    nokogiri (1.8.2-java)
+    nokogiri (1.7.2-java)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)


### PR DESCRIPTION
Seeing heap space failures when executing
`ASM::WsMan#idrac_card_enumeration` with all of the java nokogiri
1.8.x gems. Issue does not exist in the 1.7 series.