### PR TITLE
LUD-689 Fix initialization of graphite sqlite db

### DIFF
--- a/scripts/rpm/postInstall.sh
+++ b/scripts/rpm/postInstall.sh
@@ -25,7 +25,7 @@ then
   echo "SECRET_KEY = '$(openssl rand 32 -hex)'" >> /etc/graphite-web/local_settings.py
   echo "TIME_ZONE = 'UTC'" >> /etc/graphite-web/local_settings.py
 
-  python /usr/lib/python2.6/site-packages/graphite/manage.py syncdb --noinput
+  python /usr/lib/python2.7/site-packages/graphite/manage.py syncdb --noinput
   chown apache:apache /var/lib/graphite-web/graphite.db
 
   cat << EOF > /etc/carbon/storage-schemas.conf


### PR DESCRIPTION
After the upgrade to CentOS 7.x the path to the graphite manage.py
file has changed. This change is necessary but not sufficient to get
graphite fully functional again. There are still problems due to httpd
running as csadmin instead of as apache.