### PR TITLE
VXFM-1642 Fix ipaddress Gemfile.lock entry

### DIFF
--- a/files/Gemfile.lock
+++ b/files/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       domain_name (~> 0.5)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    ipaddress (~> 0.8.3)
+    ipaddress (0.8.3)
     jdbc-postgres (42.1.4)
     jruby-openssl (0.9.21-java)
     json (2.1.0-java)


### PR DESCRIPTION
The exact version has to be specified in the `Gemfile.lock`