### PR TITLE
VXFM-2344 Update rbvmomi dependency to 1.12.0

### DIFF
--- a/files/Gemfile.lock
+++ b/files/Gemfile.lock
@@ -99,7 +99,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
-    rbvmomi (1.11.7)
+    rbvmomi (1.12.0)
       builder (~> 3.0)
       json (>= 1.8)
       nokogiri (~> 1.5)
@@ -178,7 +178,7 @@ DEPENDENCIES
   puppetlabs_spec_helper (~> 0.4.1)
   rainbow (~> 2.1.0)
   rake
-  rbvmomi (~> 1.11.6)
+  rbvmomi (~> 1.12.0)
   rest-client (~> 2.0.2)
   rjack-logback
   rspec (~> 3.7.0)


### PR DESCRIPTION
The appliance has a patched version of rbvmomi 1.12.0 now to resolve
an OVF deployment issue.