### PR TITLE
VXFM-6601 Upgrade Rubocop and other gems

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -181,8 +181,8 @@ task rpm(dependsOn: copyAsmDeployer) << {
                 rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check-ipmi.rb") {
                 rpmBuilder.addFile("/usr/lib64/nagios/plugins/check-ipmi.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
-            } else if (it.path == "nagios/check-racadm.rb") {
-                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check-racadm.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
+            } else if (it.path == "nagios/check_racadm.rb") {
+                rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_racadm.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check_snmp.rb") {
                 rpmBuilder.addFile("/usr/lib64/nagios/plugins/check_snmp.rb", it.file, 0755, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/check_navisec.rb") {

--- a/files/Gemfile.lock
+++ b/files/Gemfile.lock
@@ -5,28 +5,19 @@ GEM
     ast (2.4.0)
     builder (3.2.3)
     coderay (1.1.2)
-    concurrent-ruby (1.0.5-java)
-    dell-asm-util (0.1.0)
-      aescrypt
-      hashie
-      i18n
-      net-ssh
-      nokogiri
-      pry
-      rest-client
-      trollop
+    concurrent-ruby (1.1.5)
     diff-lcs (1.3)
-    domain_name (0.5.20170404)
+    domain_name (0.5.20190701)
       unf (>= 0.0.5, < 1.0.0)
     facter (2.5.1)
     fast_gettext (1.1.2)
-    ffi (1.9.23-java)
-    fishwife (1.10.0-java)
+    ffi (1.11.1-java)
+    fishwife (1.10.1-java)
       rack (>= 1.6.4, < 2.1)
       rjack-jetty (>= 9.2.11, < 9.5)
       rjack-slf4j (~> 1.7.2)
     formatador (0.2.5)
-    guard (2.14.2)
+    guard (2.15.0)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
       lumberjack (>= 1.0.12, < 2.0)
@@ -40,100 +31,111 @@ GEM
       guard (>= 2.0.0)
       guard-compat (~> 1.0)
     hashie (3.5.7)
-    hiera (3.4.2)
+    hiera (3.5.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)
-    i18n (0.9.5)
+    i18n (1.6.0)
       concurrent-ruby (~> 1.0)
     ipaddress (0.8.3)
+    jar-dependencies (0.4.0)
+    jaro_winkler (1.5.3-java)
     jdbc-postgres (42.1.4)
     jruby-openssl (0.9.21-java)
-    json (2.1.0-java)
+    json (2.2.0-java)
     json_pure (2.0.1)
-    kramdown (1.16.2)
+    kramdown (2.1.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
       ruby_dep (~> 1.2)
     locale (2.1.2)
     logger-colors (1.0.0)
-    lumberjack (1.0.12)
+    lumberjack (1.0.13)
     metaclass (0.0.4)
-    method_source (0.9.0)
-    mime-types (3.1)
+    method_source (0.9.2)
+    mime-types (3.2.2)
       mime-types-data (~> 3.2015)
-    mime-types-data (3.2016.0521)
-    mocha (1.3.0)
+    mime-types-data (3.2019.0331)
+    mocha (1.9.0)
       metaclass (~> 0.0.1)
+    multi_json (1.13.1)
     nenv (0.3.0)
-    net-scp (1.2.1)
-      net-ssh (>= 2.6.5)
-    net-ssh (4.2.0)
+    net-scp (2.0.0)
+      net-ssh (>= 2.6.5, < 6.0.0)
+    net-ssh (5.2.0)
     netrc (0.11.0)
-    nokogiri (1.7.2-java)
+    nokogiri (1.10.3-java)
     notiffany (0.1.1)
       nenv (~> 0.1)
       shellany (~> 0.0)
-    parser (2.5.0.4)
+    optimist (3.0.0)
+    parallel (1.17.0)
+    parser (2.6.3.0)
       ast (~> 2.4.0)
-    powerpack (0.1.1)
-    pry (0.11.3-java)
+    powerpack (0.1.2)
+    pry (0.12.2-java)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
       spoon (~> 0.0)
-    puppet (5.4.0)
+    psych (3.1.0-java)
+      jar-dependencies (>= 0.1.7)
+    puppet (5.5.14)
       facter (> 2.0.1, < 4)
       fast_gettext (~> 1.1.2)
       hiera (>= 3.2.1, < 4)
       locale (~> 2.1)
+      multi_json (~> 1.10)
     puppetlabs_spec_helper (0.4.1)
       mocha (>= 0.10.5)
       rake
       rspec (>= 2.9.0)
       rspec-puppet (>= 0.1.1)
-    rack (1.6.9)
+    rack (1.6.11)
     rack-protection (1.5.5)
       rack
-    rainbow (2.1.0)
-    rake (12.3.0)
+    rainbow (3.0.0)
+    rake (12.3.2)
     rb-fsevent (0.10.3)
-    rb-inotify (0.9.10)
-      ffi (>= 0.5.0, < 2)
-    rbvmomi (1.12.0)
+    rb-inotify (0.10.0)
+      ffi (~> 1.0)
+    rbvmomi (2.2.0)
       builder (~> 3.0)
       json (>= 1.8)
       nokogiri (~> 1.5)
-      trollop (~> 2.1)
+      optimist (~> 3.0)
     rest-client (2.0.2)
       http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 4.0)
       netrc (~> 0.8)
-    rjack-jetty (9.4.6.0-java)
+    rjack-jetty (9.4.14.0-java)
     rjack-logback (1.9.0-java)
       rjack-slf4j (~> 1.7.16)
     rjack-slf4j (1.7.25.0-java)
-    rspec (3.7.0)
-      rspec-core (~> 3.7.0)
-      rspec-expectations (~> 3.7.0)
-      rspec-mocks (~> 3.7.0)
-    rspec-core (3.7.1)
-      rspec-support (~> 3.7.0)
-    rspec-expectations (3.7.0)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.2)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.4)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-mocks (3.7.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.1)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.7.0)
-    rspec-puppet (2.6.11)
+      rspec-support (~> 3.8.0)
+    rspec-puppet (2.7.5)
       rspec
-    rspec-support (3.7.1)
-    rubocop (0.47.1)
-      parser (>= 2.3.3.1, < 3.0)
+    rspec-support (3.8.2)
+    rubocop (0.65.0)
+      jaro_winkler (~> 1.5.1)
+      parallel (~> 1.10)
+      parser (>= 2.5, != 2.5.1.1)
       powerpack (~> 0.1)
-      rainbow (>= 1.99.1, < 3.0)
+      psych (>= 3.1.0)
+      rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
-      unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.9.0)
+      unicode-display_width (~> 1.4.0)
+    ruby-progressbar (1.10.1)
     ruby_dep (1.5.0)
     sequel (5.5.0)
     shellany (0.0.1)
@@ -143,25 +145,35 @@ GEM
       tilt (>= 1.3, < 3)
     spoon (0.0.6)
       ffi
-    thor (0.20.0)
-    tilt (2.0.8)
-    trollop (2.1.2)
+    thor (0.20.3)
+    tilt (2.0.9)
+    trollop (2.1.3)
     unf (0.1.4-java)
-    unicode-display_width (1.3.0)
-    yard (0.9.12)
+    unicode-display_width (1.4.1)
+    unix-crypt (1.3.0)
+    yard (0.9.20)
 
 PLATFORMS
   java
 
 DEPENDENCIES
   aescrypt (~> 1.0.0)
-  concurrent-ruby (~> 1.0.0)
+  concurrent-ruby
+  dell-asm-util (0.1.0)
+    aescrypt
+    hashie
+    i18n
+    net-ssh
+    nokogiri
+    pry
+    rest-client
+    trollop
   coveralls
-  dell-asm-util (~> 0.1.0)
+  dell-asm-util! (~> 0.1.0)
   fishwife
   guard-shell
   hashie (~> 3.5.7)
-  i18n (~> 0.9.4)
+  i18n
   ipaddress (~> 0.8.3)
   jdbc-postgres (~> 42.1.4)
   jruby-openssl (~> 0.9.17)
@@ -172,31 +184,24 @@ DEPENDENCIES
   mocha
   net-scp
   net-ssh
-  nokogiri (~> 1.8.2)
+  nokogiri
   pg (~> 1.0.0)
-  puppet
+  puppet (~> 5)
   puppetlabs_spec_helper (~> 0.4.1)
-  rainbow (~> 2.1.0)
+  rainbow
   rake
-  rbvmomi (~> 1.12.0)
+  rbvmomi
   rest-client (~> 2.0.2)
   rjack-logback
-  rspec (~> 3.7.0)
-  rubocop (= 0.47.1)
+  rspec
+  rubocop (= 0.65.0)
   ruby-prof (~> 0.17.0)
   sequel (~> 5.5.0)
   sinatra (~> 1.4.5)
-  sys-admin
   trollop (~> 2.1.2)
-  unicode-display_width (~> 1.3.0)
-  win32-dir
-  win32-process
-  win32-security
-  win32-service
-  win32-taskscheduler
-  windows-pr
-  yard
+  unicode-display_width
   unix-crypt (~> 1.3.0)
+  yard
 
 BUNDLED WITH
-   1.16.1
+   2.0.1


### PR DESCRIPTION
- update Gemfile.lock

- check-racadm.rb was renamed to check_racadm.rb to meet rubocop
  requirements