### PR TITLE
VXFM-9513 root email account received error messages while cleaning u…

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -214,8 +214,6 @@ task rpm(dependsOn: copyAsmDeployer) << {
                 rpmBuilder.addFile("/etc/cron.d/asm_nagios_remove_stale_logs.cron", it.file, 0644, -1, Directive.NONE, 'root', 'root', false)
             } else if (it.path == "nagios/graphite-web.conf") {
                 rpmBuilder.addFile("/etc/httpd/conf.d/asm-graphite-web.conf", it.file, 0644, -1, Directive.NONE, 'root', 'root', false)
-            } else if (it.path == "nagios/logrotate.graphite") {
-                rpmBuilder.addFile("/etc/logrotate.d/graphite", it.file, 0644, -1, Directive.NONE, 'root', 'root', false)
             } else {
                 rpmBuilder.addFile("/opt/asm-deployer/${it.path}", it.file, 0644, -1, Directive.NONE, 'root', 'razor', false)
             }


### PR DESCRIPTION
…p mail for cron jobs

Remove unnecessary logrotate conf file 'graphite'. There is an existing
file ('/etc/logrotate.d/python-carbon') which targets exactly the same
log directory and files and was causing unnecessary root emails containing
error messages about the duplicate logrotate entry.